### PR TITLE
Fix admin dashboard client switching logic

### DIFF
--- a/app/Http/Controllers/Admin/AdminDashboardController.php
+++ b/app/Http/Controllers/Admin/AdminDashboardController.php
@@ -21,16 +21,14 @@ class AdminDashboardController extends Controller
         $clientOptions = User::query()
             ->where('is_admin', false)
             ->orderBy('name')
-            ->pluck('name', 'id');
+            ->get(['id', 'name'])
+            ->mapWithKeys(function (User $user) {
+                $label = $user->name ?: sprintf('User #%d', $user->id);
 
-        $selectedUserId = $request->integer('user');
-        if ($selectedUserId && ! $clientOptions->has($selectedUserId)) {
-            $selectedUserId = null;
-        }
+                return [$user->id => $label];
+            });
 
-        if (! $selectedUserId && $clientOptions->isNotEmpty()) {
-            $selectedUserId = (int) $clientOptions->keys()->first();
-        }
+        $selectedUserId = $request->integer('user') ?: null;
 
         $selectedUser = null;
         $accounts = collect();
@@ -41,8 +39,9 @@ class AdminDashboardController extends Controller
 
         $selectedAccount = null;
 
-        if ($selectedUserId) {
-            $selectedUser = User::query()
+        $loadSelectedUser = static function (int $userId): ?User {
+            return User::query()
+                ->where('is_admin', false)
                 ->with([
                     'accounts' => function (Relation $query) {
                         $query
@@ -53,21 +52,34 @@ class AdminDashboardController extends Controller
                     'transactions' => fn (Relation $query) => $query->latest()->limit(10),
                     'documents' => fn (Relation $query) => $query->latest()->limit(5),
                     'fraudClaims' => fn (Relation $query) => $query->latest()->limit(5),
-                    'withdrawals' => fn (Relation $query) => $query->latest()->limit(5),
+                    'withdrawals' => function (Relation $query) {
+                        $query->with('fromAccount')->latest()->limit(5);
+                    },
                 ])
-                ->find($selectedUserId);
+                ->find($userId);
+        };
 
-            if ($selectedUser) {
-                $accounts = $selectedUser->accounts;
-                $transactions = $selectedUser->transactions;
-                $documents = $selectedUser->documents;
-                $fraudClaims = $selectedUser->fraudClaims;
-                $withdrawals = $selectedUser->withdrawals;
+        $validUserIds = $clientOptions->keys()->map(static fn ($key) => (int) $key);
 
-                if ($accounts->isNotEmpty()) {
-                    $requestedAccountId = $request->integer('account');
-                    $selectedAccount = $accounts->firstWhere('id', $requestedAccountId) ?? $accounts->first();
-                }
+        if ($selectedUserId !== null && $validUserIds->contains($selectedUserId)) {
+            $selectedUser = $loadSelectedUser($selectedUserId);
+        }
+
+        if (! $selectedUser && $validUserIds->isNotEmpty()) {
+            $selectedUserId = $validUserIds->first();
+            $selectedUser = $loadSelectedUser($selectedUserId);
+        }
+
+        if ($selectedUser) {
+            $accounts = $selectedUser->accounts;
+            $transactions = $selectedUser->transactions;
+            $documents = $selectedUser->documents;
+            $fraudClaims = $selectedUser->fraudClaims;
+            $withdrawals = $selectedUser->withdrawals;
+
+            if ($accounts->isNotEmpty()) {
+                $requestedAccountId = $request->integer('account');
+                $selectedAccount = $accounts->firstWhere('id', $requestedAccountId) ?? $accounts->first();
             }
         }
 

--- a/tests/Feature/AdminDashboardTest.php
+++ b/tests/Feature/AdminDashboardTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Account;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AdminDashboardTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['integration.theme_routes' => true]);
+    }
+
+    public function test_admin_can_switch_between_clients(): void
+    {
+        $admin = User::factory()->create([
+            'is_admin' => true,
+            'currency' => 'EUR',
+            'main_balance' => 0,
+            'verification_status' => 'approved',
+        ]);
+
+        $firstClient = User::factory()->create([
+            'name' => 'Alice Client',
+            'is_admin' => false,
+            'currency' => 'USD',
+            'main_balance' => 1500,
+            'verification_status' => 'approved',
+        ]);
+
+        $secondClient = User::factory()->create([
+            'name' => 'Bob Client',
+            'is_admin' => false,
+            'currency' => 'GBP',
+            'main_balance' => 2750,
+            'verification_status' => 'active',
+        ]);
+
+        Account::create([
+            'user_id' => $secondClient->id,
+            'number' => 'ACC-2001',
+            'type' => 'Classic',
+            'organization' => 'Acme Corp',
+            'client_initials' => 'B. C.',
+            'broker_initials' => 'Agent',
+            'term' => now()->addYear(),
+            'status' => 'Active',
+            'balance' => 9999.99,
+            'currency' => 'GBP',
+            'is_default' => true,
+        ]);
+
+        $response = $this->actingAs($admin)->get(route('admin.dashboard', ['user' => $secondClient->id]));
+
+        $response->assertOk();
+        $response->assertViewHas('selectedUserId', $secondClient->id);
+        $response->assertSee('Bob Client', false);
+        $response->assertSee('ACC-2001', false);
+        $response->assertSee('value="' . $secondClient->id . '" selected', false);
+    }
+
+    public function test_dashboard_defaults_to_first_client_when_selected_user_missing(): void
+    {
+        $admin = User::factory()->create([
+            'is_admin' => true,
+            'currency' => 'EUR',
+            'main_balance' => 0,
+            'verification_status' => 'approved',
+        ]);
+
+        $firstClient = User::factory()->create([
+            'name' => 'First Client',
+            'is_admin' => false,
+            'currency' => 'EUR',
+            'main_balance' => 1000,
+            'verification_status' => 'approved',
+        ]);
+
+        $secondClient = User::factory()->create([
+            'name' => 'Second Client',
+            'is_admin' => false,
+            'currency' => 'USD',
+            'main_balance' => 2000,
+            'verification_status' => 'pending',
+        ]);
+
+        $response = $this->actingAs($admin)->get(route('admin.dashboard', ['user' => 99999]));
+
+        $response->assertOk();
+        $response->assertViewHas('selectedUserId', function ($value) use ($firstClient, $secondClient) {
+            return in_array($value, [$firstClient->id, $secondClient->id], true);
+        });
+        $response->assertSee('First Client', false);
+        $response->assertSee('Second Client', false);
+    }
+}


### PR DESCRIPTION
## Summary
- normalize client option keys and reuse existing loader to hydrate dashboard data
- ensure withdrawals eager load their source account and keep the chosen client when switching
- add a feature test covering client selection and default fallback behaviour

## Testing
- php artisan test

------
https://chatgpt.com/codex/tasks/task_e_68d363b3028c832195d4dfc5c414cc22